### PR TITLE
add support for iptables-legacy and ip6tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "clap",
  "prometheus",
  "prometheus-hyper",
+ "strum",
  "thiserror",
  "tokio",
  "tracing",
@@ -486,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +537,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ anyhow = "1.0.40"
 clap = {version= "4.0.0", features = ["derive", "cargo", "wrap_help"]}
 prometheus = "0.13.3"
 prometheus-hyper = "0.1.2"
+strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1.0.24"
 tokio = { version = "1.5.0", features = ["full"] }
 tracing = "0.1.25"

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 
 An asynchronous Prometheus exporter for `iptables`
 
-`iptables_exporter` runs `iptables-save --counter` and scrapes the output to
-build Prometheus metrics. Because `iptables-save` requires `root` privileges,
-this tool must be run as `root` (or via `sudo`) or with the following
-capabilities in both the ambient and bounding set:
+`iptables_exporter` runs one of several backend "scrape targets" such as
+`iptables-save --counter` and scrapes the output to build Prometheus metrics.
+Because these scrape targets require `root` privileges, this tool must be run as
+`root` (or via `sudo`) or with the following capabilities in both the ambient
+and bounding set:
 
 - CAP_DAC_READ_SEARCH
 - CAP_NET_ADMIN
@@ -22,6 +23,25 @@ capabilities in both the ambient and bounding set:
 - Total number of chains per table
 - Scrape duration in milliseconds
 - Scrape success
+
+# Scrape Targets Supported
+
+- `iptables-save`
+- `ip6tables-save`
+- `iptables-legacy-save`
+- `ip6tables-legacy-save`
+
+Multiple scrape targets can be enabled at once by using the
+`-t|--scrape-targets` flag multiple times. Such as:
+
+```
+$ iptables_exporter -t iptables -t iptables-legacy -t ip6tables
+```
+
+By default only `iptables` is enabled.
+
+The metrics provided will be prefixed with the various scrape targets, such as
+`iptables_*`, `iptables_legacy_*`, etc. 
 
 # Installation
 
@@ -46,20 +66,49 @@ $ sudo cp target/release/iptables_exporter /usr/local/bin/
 ## Command Line Interface
 
 ```
-USAGE:
-    iptables_exporter [FLAGS] [OPTIONS]
+Usage: iptables_exporter [OPTIONS]
 
-FLAGS:
-    -h, --help       Prints help information
-    -q, --quiet      Supress output at a level or lower. -q: INFO, -qq: WARN, -qqq: ERROR (i.e.
-                     everything)
-    -v, --verbose    Show verbose output at a level or higher. -v:  DEBUG, -vv: TRACE
-    -V, --version    Prints version information
+Options:
+      --collect-interval <SECS>
+          How often metrics are gathered
 
-OPTIONS:
-        --collect-interval <SECS>    How often metrics are gathered [default: 5]
-    -l, --listen-address <ADDR>      The listen address scraping metrics [default: 0.0.0.0]
-    -p, --listen-port <PORT>         The listen port for scraping metrics [default: 9455]
+          [default: 5]
+
+  -p, --listen-port <PORT>
+          The listen port for scraping metrics
+
+          [default: 9455]
+
+  -l, --listen-address <ADDR>
+          The listen address scraping metrics
+
+          [default: 0.0.0.0]
+
+  -t, --scrape-targets <TARGET>
+          Which backends to scrape for metrics, multiple targets can be enabled at
+          once by using this flag multiple times
+
+          [default: iptables]
+          [aliases: scrape-target]
+
+          Possible values:
+          - iptables:         enable 'iptables-save' for metrics
+          - ip6tables:        enable 'ip6tables-save' for metrics
+          - iptables-legacy:  enable 'iptables-legacy-save' for metrics
+          - ip6tables-legacy: enable 'ip6tables-legacy-save' for metrics
+
+  -v, --verbose...
+          Show verbose output at a level or higher. -v:  DEBUG, -vv: TRACE
+
+  -q, --quiet...
+          Supress output at a level or lower. -q: INFO, -qq: WARN, -qqq: ERROR (i.e.
+          everything)
+
+  -h, --help
+          Print help information (use `-h` for a summary)
+
+  -V, --version
+          Print version information
 ```
 
 To run with the default options, and the binary is installed somewhere in your

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,10 @@ pub(crate) struct Args {
     /// The listen address scraping metrics
     #[arg(short, long, default_value = "0.0.0.0", value_name = "ADDR")]
     pub(crate) listen_address: IpAddr,
+    /// Which backends to scrape for metrics, multiple targets can be enabled at
+    /// once by using this flag multiple times
+    #[arg(short = 't', long, visible_alias = "scrape-target", default_value = "iptables", action = ArgAction::Append, value_enum, value_name = "TARGET")]
+    pub(crate) scrape_targets: Vec<ScrapeTarget>,
     /// Show verbose output at a level or higher. -v:  DEBUG, -vv: TRACE
     #[arg(long, short, action = ArgAction::Count)]
     pub(crate) verbose: u8,
@@ -25,4 +29,20 @@ pub(crate) struct Args {
     /// (i.e. everything)
     #[arg(long, short, overrides_with = "verbose", action = ArgAction::Count)]
     pub(crate) quiet: u8,
+}
+
+#[derive(clap::ValueEnum, PartialEq, Eq, Copy, Clone, Debug, strum::AsRefStr, strum::Display)]
+pub(crate) enum ScrapeTarget {
+    /// enable 'iptables-save' for metrics
+    #[strum(serialize = "iptables")]
+    Iptables,
+    /// enable 'ip6tables-save' for metrics
+    #[strum(serialize = "ip6tables")]
+    Ip6tables,
+    /// enable 'iptables-legacy-save' for metrics
+    #[strum(serialize = "iptables-legacy")]
+    IptablesLegacy,
+    /// enable 'ip6tables-legacy-save' for metrics
+    #[strum(serialize = "ip6tables-legacy")]
+    Ip6tablesLegacy,
 }

--- a/src/iptables.rs
+++ b/src/iptables.rs
@@ -1,10 +1,3 @@
-use std::{result::Result as StdResult, str::FromStr};
-
-use anyhow::{Context, Result};
-use tokio::process::Command;
-
-use crate::error::IptablesError;
-
 mod chain;
 mod counter;
 mod metrics;
@@ -17,16 +10,25 @@ pub(crate) use metrics::Metrics;
 pub(crate) use rule::Rule;
 pub(crate) use table::Table;
 
-pub(crate) async fn iptables_save() -> Result<String> {
+use std::{result::Result as StdResult, str::FromStr};
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+use crate::{cli::ScrapeTarget, error::IptablesError};
+
+pub(crate) async fn iptables_save(tgt: ScrapeTarget) -> Result<String> {
+    let cmd = format!("{tgt}-save");
+
     String::from_utf8(
-        Command::new("iptables-save")
+        Command::new(&cmd)
             .arg("-c")
             .output()
             .await
-            .with_context(|| "Failed to run iptables-save")?
+            .with_context(|| format!("Failed to run {cmd}"))?
             .stdout,
     )
-    .with_context(|| "Failed iptables-save output to valid UTF-8")
+    .with_context(|| format!("Failed {cmd} output to valid UTF-8"))
 }
 
 #[allow(dead_code)]

--- a/src/iptables/metrics.rs
+++ b/src/iptables/metrics.rs
@@ -1,10 +1,12 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use prometheus::{IntCounterVec, IntGaugeVec, Opts, Registry};
 use tracing::{debug, trace};
 
-use crate::iptables::IptablesState;
+use crate::{cli::ScrapeTarget, iptables::IptablesState};
 
-pub(crate) struct Metrics {
+pub(crate) struct TargetMetrics {
     chains_total: IntGaugeVec,
     rules_total: IntGaugeVec,
     chain_bytes_total: IntCounterVec,
@@ -13,74 +15,8 @@ pub(crate) struct Metrics {
     rule_packets_total: IntCounterVec,
 }
 
-impl Metrics {
-    pub(crate) fn new(r: &Registry) -> Result<Self> {
-        trace!("Metrics::new");
-
-        let chains_total = IntGaugeVec::new(
-            Opts::new("iptables_chains_total", "Total number of chains in a table"),
-            &["table"],
-        )?;
-
-        let rules_total = IntGaugeVec::new(
-            Opts::new(
-                "iptables_rules_total",
-                "Total number of rules in a chain in a table",
-            ),
-            &["table", "chain"],
-        )?;
-
-        let chain_bytes_total = IntCounterVec::new(
-            Opts::new(
-                "iptables_chain_bytes_total",
-                "Total bytes flowing through a given chain",
-            ),
-            &["table", "chain", "policy"],
-        )?;
-
-        let chain_packets_total = IntCounterVec::new(
-            Opts::new(
-                "iptables_chain_packets_total",
-                "Total packets flowing through a given chain",
-            ),
-            &["table", "chain", "policy"],
-        )?;
-
-        let rule_bytes_total = IntCounterVec::new(
-            Opts::new(
-                "iptables_rule_bytes_total",
-                "Total bytes matching a given rule",
-            ),
-            &["table", "chain", "rule"],
-        )?;
-
-        let rule_packets_total = IntCounterVec::new(
-            Opts::new(
-                "iptables_rule_packets_total",
-                "Total packets matching a given rule",
-            ),
-            &["table", "chain", "rule"],
-        )?;
-
-        debug!("Registering iptables metrics");
-        r.register(Box::new(chain_bytes_total.clone()))?;
-        r.register(Box::new(chain_packets_total.clone()))?;
-        r.register(Box::new(rule_bytes_total.clone()))?;
-        r.register(Box::new(rule_packets_total.clone()))?;
-        r.register(Box::new(rules_total.clone()))?;
-        r.register(Box::new(chains_total.clone()))?;
-
-        Ok(Self {
-            chains_total,
-            rules_total,
-            chain_bytes_total,
-            chain_packets_total,
-            rule_bytes_total,
-            rule_packets_total,
-        })
-    }
-
-    pub(crate) async fn update(&mut self, state: &IptablesState) {
+impl TargetMetrics {
+    fn update(&mut self, state: &IptablesState) {
         for t in &state.tables {
             let ct = self.chains_total.with_label_values(&[&t.name]);
             ct.set(t.chains.len() as i64);
@@ -115,6 +51,96 @@ impl Metrics {
                     rbt.inc_by(diff);
                 }
             }
+        }
+    }
+}
+
+pub(crate) struct Metrics {
+    map: HashMap<String, TargetMetrics>,
+}
+
+impl Metrics {
+    pub(crate) fn new(targets: &[ScrapeTarget], r: &Registry) -> Result<Self> {
+        trace!("Metrics::new");
+
+        let mut map = HashMap::new();
+        for tgt in targets {
+            let prefix = tgt.as_ref().replace('-', "_");
+
+            let chains_total = IntGaugeVec::new(
+                Opts::new(
+                    &format!("{prefix}_chains_total"),
+                    "Total number of chains in a table",
+                ),
+                &["table"],
+            )?;
+
+            let rules_total = IntGaugeVec::new(
+                Opts::new(
+                    &format!("{prefix}_rules_total"),
+                    "Total number of rules in a chain in a table",
+                ),
+                &["table", "chain"],
+            )?;
+
+            let chain_bytes_total = IntCounterVec::new(
+                Opts::new(
+                    &format!("{prefix}_chain_bytes_total"),
+                    "Total bytes flowing through a given chain",
+                ),
+                &["table", "chain", "policy"],
+            )?;
+
+            let chain_packets_total = IntCounterVec::new(
+                Opts::new(
+                    &format!("{prefix}_chain_packets_total"),
+                    "Total packets flowing through a given chain",
+                ),
+                &["table", "chain", "policy"],
+            )?;
+
+            let rule_bytes_total = IntCounterVec::new(
+                Opts::new(
+                    &format!("{prefix}_rule_bytes_total"),
+                    "Total bytes matching a given rule",
+                ),
+                &["table", "chain", "rule"],
+            )?;
+
+            let rule_packets_total = IntCounterVec::new(
+                Opts::new(
+                    &format!("{prefix}_rule_packets_total"),
+                    "Total packets matching a given rule",
+                ),
+                &["table", "chain", "rule"],
+            )?;
+
+            debug!("Registering {prefix} metrics");
+            r.register(Box::new(chain_bytes_total.clone()))?;
+            r.register(Box::new(chain_packets_total.clone()))?;
+            r.register(Box::new(rule_bytes_total.clone()))?;
+            r.register(Box::new(rule_packets_total.clone()))?;
+            r.register(Box::new(rules_total.clone()))?;
+            r.register(Box::new(chains_total.clone()))?;
+            map.insert(
+                tgt.to_string(),
+                TargetMetrics {
+                    chains_total,
+                    rules_total,
+                    chain_bytes_total,
+                    chain_packets_total,
+                    rule_bytes_total,
+                    rule_packets_total,
+                },
+            );
+        }
+
+        Ok(Self { map })
+    }
+
+    pub(crate) fn update(&mut self, tgt: ScrapeTarget, state: &IptablesState) {
+        if let Some(tgt_metrics) = self.map.get_mut(tgt.as_ref()) {
+            tgt_metrics.update(state);
         }
     }
 }


### PR DESCRIPTION
Adds support for `ip{6}tables{-legacy}` via the new
`-t|--scrape-targets` CLI flag.

Multiple scrape targets can be enabled at once by using the
`-t|--scrape-targets` flag multiple times. Such as:

```
$ iptables_exporter -t iptables -t iptables-legacy -t ip6tables
```

By default only `iptables` is enabled.

The metrics provided will be prefixed with the various scrape targets, such as
`iptables_*`, `iptables_legacy_*`, etc.

Closes #3
Closes #4
